### PR TITLE
Support for static and fixes

### DIFF
--- a/spec/FileParserSpec.ts
+++ b/spec/FileParserSpec.ts
@@ -399,7 +399,11 @@ describe("FileParser", function () {
 			expect(file.classes[0].fields[0].isStatic).toBe(true);
 			expect(file.classes[0].fields[1].isPublic).toBe(true);
 			expect(file.classes[0].fields[1].isStatic).toBe(false);
-			expect(file.classes[0].methods[0].isStatic).toBe(true);
+            expect(file.classes[0].methods[0].isStatic).toBe(true);
+            expect(file.classes[0].constructors[0].isPublic).toBe(true);
+            expect(file.classes[0].constructors[0].isStatic).toBe(true);
+            expect(file.classes[0].constructors[0].parameters[0].name).toBe("str");
+            expect(file.classes[0].constructors[0].parameters[0].type.name).toBe("string");
 		}));
 
     });

--- a/spec/FileParserSpec.ts
+++ b/spec/FileParserSpec.ts
@@ -397,8 +397,8 @@ describe("FileParser", function () {
 			expect(file.classes[0].properties[0].isStatic).toBe(true);
 			expect(file.classes[0].fields[0].isPublic).toBe(false);
 			expect(file.classes[0].fields[0].isStatic).toBe(true);
-			expect(file.classes[0].fields[0].isPublic).toBe(true);
-			expect(file.classes[0].fields[0].isStatic).toBe(false);
+			expect(file.classes[0].fields[1].isPublic).toBe(true);
+			expect(file.classes[0].fields[1].isStatic).toBe(false);
 			expect(file.classes[0].methods[0].isStatic).toBe(true);
 		}));
 

--- a/spec/csharp/Static.cs
+++ b/spec/csharp/Static.cs
@@ -12,4 +12,8 @@ public static class MyPoco
 
 	}
 
+	public static MyPoco(string str)
+	{
+
+	}
 }

--- a/src/ClassParser.ts
+++ b/src/ClassParser.ts
@@ -53,6 +53,7 @@ export class ClassParser {
 
                         var classObject = new CSharpClass(name);
                         classObject.isPublic = modifiers.indexOf("public") > -1;
+                        classObject.isStatic = modifiers.indexOf("static") > -1;
                         classObject.attributes = this.attributeParser.parseAttributes(attributes);
                         classObject.innerScopeText = scope.content;
                         classObject.genericParameters = this.typeParser.parseTypesFromGenericParameters(genericParameters);

--- a/src/FieldParser.ts
+++ b/src/FieldParser.ts
@@ -28,17 +28,19 @@ export class FieldParser {
             for(var statement of statements) {
                 var matches = this.regexHelper.getMatches(
                     statement,
-                    new RegExp("^" + this.regexHelper.getFieldRegex(false, true, true, true, true) + "$", "g"));
+                    new RegExp("^" + this.regexHelper.getFieldRegex(false, true, true, true, true, true) + "$", "g"));
                 for (var match of matches) {
                     try {
                         var attributes = match[0];
                         var modifiers = match[1] || "";
                         var returnType = match[2];
                         var name = match[3];
+                        var initialValue = match[4];
 
                         var field = new CSharpField(name);
                         field.attributes = this.attributeParser.parseAttributes(attributes);
                         field.type = this.typeParser.parseType(returnType);
+                        field.initialValue = initialValue;
 
                         field.isPublic = modifiers.indexOf("public") > -1;
                         field.isStatic = modifiers.indexOf("static") > -1;

--- a/src/FieldParser.ts
+++ b/src/FieldParser.ts
@@ -41,6 +41,7 @@ export class FieldParser {
                         field.type = this.typeParser.parseType(returnType);
 
                         field.isPublic = modifiers.indexOf("public") > -1;
+                        field.isStatic = modifiers.indexOf("static") > -1;
                         field.isReadOnly = modifiers.indexOf("readonly") > -1;
 
                         fields.push(field);

--- a/src/MethodParser.ts
+++ b/src/MethodParser.ts
@@ -64,6 +64,7 @@ export class MethodParser {
 						}
 
 						method.isPublic = modifiers.indexOf("public") > -1;
+						method.isStatic = modifiers.indexOf("static") > -1;
 						method.isBodyless = openingType === ";";
 
 						methods.push(method);

--- a/src/MethodParser.ts
+++ b/src/MethodParser.ts
@@ -46,6 +46,12 @@ export class MethodParser {
 						var parameters = match[5];
 						var openingType = match[6];
 
+						var catchNoReturnType = this.regexHelper.getMatches(returnType, new RegExp("^" + this.regexHelper.getModifierRegex(true) + "$", "g"));
+						if (catchNoReturnType.length > 0 && catchNoReturnType[0].length > 0) {
+							modifiers += (modifiers ? " " : "") + catchNoReturnType[0][0]
+							returnType = "";
+						}
+
 						var method = new CSharpMethod(name);
 						method.attributes = this.attributeParser.parseAttributes(attributes);
 						method.genericParameters = this.typeParser.parseTypesFromGenericParameters(genericParameters);

--- a/src/PropertyParser.ts
+++ b/src/PropertyParser.ts
@@ -47,6 +47,7 @@ export class PropertyParser {
 
 						property.isVirtual = modifiers.indexOf("virtual") > -1;
 						property.isPublic = modifiers.indexOf("public") > -1;
+						property.isStatic = modifiers.indexOf("static") > -1;
 
 						if(openingType === "{") {
 							var subScopes = this.scopeHelper.getCurlyScopes(scope.content);

--- a/src/RegExHelper.ts
+++ b/src/RegExHelper.ts
@@ -157,7 +157,8 @@
 		captureAttributes: boolean,
 		captureModifiers: boolean,
 		captureReturnType: boolean,
-		captureName: boolean) 
+		captureName: boolean,
+		captureInitialValue: boolean) 
 	{
 		var result = "";
 
@@ -165,6 +166,7 @@
 		result += this.getModifiersRegex(captureModifiers);
 		result += this.getGenericTypeNameRegex(captureReturnType, false, false, false, false);
 		result += this.getNameRegex(captureName);
+		result += this.getInitialValueRegex(captureInitialValue);
 		result += this.wrapInGroup(false, true, ";");
 
 		return this.wrapInGroup(capture, false, result);
@@ -298,7 +300,7 @@
 	}
 
 	public getGenericTypeWrapperRegex(capture: boolean, captureContents: boolean) {
-		return this.wrapInGroup(capture, true, "<" + this.wrapInGroup(captureContents, true, ".+") + ">") + "??";
+		return this.wrapInGroup(capture, true, "<" + this.wrapInGroup(captureContents, true, "[^=]+") + ">") + "??";
 	}
 
 	public getTypeConstraintRegex(capture: boolean) {
@@ -409,6 +411,13 @@
 
 	public getInterfaceRegex() {
 		return this.getClassOrInterfaceRegex("interface");
+	}
+
+	public getInitialValueRegex(capture: boolean) {
+		var result = this.wrapInGroup(false, true, "=");
+		result += this.wrapInGroup(capture, true, "[^;]+?");
+
+		return this.wrapInGroup(false, false, result) + "??";
 	}
 
 	public getMatches(input: string, regex: RegExp) {


### PR DESCRIPTION
I couldn't figure out how to change the regex to have constructors capture all modifiers, it still puts the last modifier as returnType.
I now just check if the returnType matches with the modifier regex and then move it over.

I had to change the generic regex to exclude the equal (`=`) sign, otherwise it would recognise initialized fields as methods. I'm not aware of any valid use cases for using the `=` sign within generics.